### PR TITLE
优化多线程分片下载

### DIFF
--- a/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/model/DownloaderConfig.kt
+++ b/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/model/DownloaderConfig.kt
@@ -6,6 +6,7 @@ import com.awesome.dhs.tools.downloader.interfac.ILogger
 import com.awesome.dhs.tools.downloader.interfac.NoOpLogger
 import okhttp3.OkHttpClient
 import java.io.File
+import java.lang.RuntimeException
 import java.util.concurrent.TimeUnit
 
 /**
@@ -16,6 +17,7 @@ import java.util.concurrent.TimeUnit
  **/
 data class DownloaderConfig(
     val maxConcurrentDownloads: Int,
+    val downloadThreadCount: Int,
     val finalDirectory: String,
     val logger: ILogger,
     val httpClient: OkHttpClient
@@ -26,6 +28,8 @@ data class DownloaderConfig(
     class Builder(context: Context) {
         private var maxConcurrentDownloads: Int = 3
         private var httpClient: OkHttpClient? = null
+
+        private var downloadThreadCount: Int? = null
         private var finalDirectory: String =
             (context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
                 ?: File(context.filesDir, "downloads")).absolutePath // [CHANGE] File -> String
@@ -40,10 +44,18 @@ data class DownloaderConfig(
 
         fun setLogger(logger: ILogger) = apply { this.logger = logger }
 
+        fun setDownloadThreadCount(threadCount: Int) = apply {
+            if (threadCount <= 0) {
+                throw RuntimeException("threadCount mast > 0")
+            }
+            this.downloadThreadCount = threadCount
+        }
+
         fun build(): DownloaderConfig {
             return DownloaderConfig(
                 maxConcurrentDownloads = maxConcurrentDownloads,
                 finalDirectory = finalDirectory,
+                downloadThreadCount = downloadThreadCount ?: DEFAULT_THREAD_COUNT,
                 logger = logger,
                 httpClient = this.httpClient ?: OkHttpClient.Builder()
                     .connectTimeout(30, TimeUnit.SECONDS) // 连接超时
@@ -54,4 +66,9 @@ data class DownloaderConfig(
             )
         }
     }
+
+    companion object {
+        private const val DEFAULT_THREAD_COUNT = 3
+    }
+
 }

--- a/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/model/DownloaderConfig.kt
+++ b/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/model/DownloaderConfig.kt
@@ -45,8 +45,8 @@ data class DownloaderConfig(
         fun setLogger(logger: ILogger) = apply { this.logger = logger }
 
         fun setDownloadThreadCount(threadCount: Int) = apply {
-            if (threadCount <= 0) {
-                throw RuntimeException("threadCount mast > 0")
+            if (threadCount !in 1..5) {
+                throw RuntimeException("threadCount mast > 1..5")
             }
             this.downloadThreadCount = threadCount
         }

--- a/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/strategy/HttpDownloadStrategy.kt
+++ b/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/strategy/HttpDownloadStrategy.kt
@@ -1,149 +1,79 @@
 package com.awesome.dhs.tools.downloader.strategy
 
-
-/**
- * FileName: HttpDownloadStrategy
- * Author: haosen
- * Date: 10/3/2025 4:44 AM
- * Description:
- **/
-import com.awesome.dhs.tools.downloader.DownloaderManager
-import com.awesome.dhs.tools.downloader.core.DownloadDispatcher.Companion.TAG
 import com.awesome.dhs.tools.downloader.db.DownloadTaskEntity
 import com.awesome.dhs.tools.downloader.interfac.IDownloadStrategy
 import com.awesome.dhs.tools.downloader.model.DownloadState
 import com.awesome.dhs.tools.downloader.model.DownloadStatus
-import com.awesome.dhs.tools.downloader.utils.FileNameResolver.getMimeType
-import com.awesome.dhs.tools.downloader.utils.FileUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import java.io.File
-import java.io.IOException
-import java.io.RandomAccessFile
-import kotlin.coroutines.cancellation.CancellationException
 
+/**
+ * 下载策略分发器（核心）
+ * 1. 检测目标URL是否支持断点续传（Range请求）
+ * 2. 支持 → 分发到多线程策略
+ * 3. 不支持 → 分发到单线程策略
+ */
 class HttpDownloadStrategy : IDownloadStrategy {
-    companion object {
-        // How often to update progress and speed, in milliseconds.
-        private const val PROGRESS_UPDATE_INTERVAL = 1000L
-    }
+    private val multiDownloadStrategy by lazy { HttpMultiDownloadStrategy() }
+    private val singleDownloadStrategy by lazy { HttpSingleDownloadStrategy() }
 
     override fun download(
         task: DownloadTaskEntity,
         client: OkHttpClient,
-        stateChecker: suspend () -> DownloadStatus?,
+        stateChecker: suspend () -> DownloadStatus?
     ): Flow<DownloadState> = flow {
-        val tempFile = File(task.tempFilePath)
-        val downloadedBytes = if (tempFile.exists()) tempFile.length() else 0L
+        // 步骤1：检测是否支持断点续传（HEAD请求验证Accept-Ranges头）
+        val isRangeSupported = checkRangeSupport(task.url, client)
 
-        // 1. 构建支持断点续传的请求
-        val request = Request.Builder()
-            .url(task.url)
-            .header("Range", "bytes=$downloadedBytes-")
-            .apply { task.headers.forEach { (key, value) -> addHeader(key, value) } }
-            .build()
-
-        val response = try {
-            client.newCall(request).execute()
-        } catch (e: IOException) {
-            emit(DownloadState.Error("Network error: ${e.message}", e))
-            return@flow
+        // 步骤2：分发策略并转发结果
+        val downloadFlow = if (isRangeSupported) {
+            // 支持断点续传 → 多线程下载
+            multiDownloadStrategy.download(task, client, stateChecker)
+        } else {
+            // 不支持断点续传 → 单线程下载
+            singleDownloadStrategy.download(task, client, stateChecker)
         }
 
-        if (!response.isSuccessful && response.code != 206) { // 206 Partial Content
-            emit(DownloadState.Error("Unexpected response code: ${response.code}"))
-            return@flow
+        // 步骤3：转发具体策略的下载状态
+        downloadFlow.collect { state ->
+            emit(state)
         }
+    }.flowOn(Dispatchers.IO)
 
-        // 2. 获取文件总大小
-        val totalBytes =
-            response.header("Content-Length")?.toLongOrNull()?.let { it + downloadedBytes }
-                ?: (task.totalBytes.takeIf { it > 0 } ?: -1L)
+    /**
+     * 核心检测逻辑：验证URL是否支持Range请求（断点续传）
+     */
+    private fun checkRangeSupport(url: String, client: OkHttpClient): Boolean {
+        return try {
+            val request = Request.Builder()
+                .url(url)
+                .head() // HEAD请求：仅获取响应头，不下载内容
+                .build()
 
-        val mimeType = task.fileName.getMimeType() ?: response.header("Content-Type")
-        if (totalBytes == -1L && downloadedBytes == 0L) {
-            emit(DownloadState.Error("Could not determine file size."))
-            return@flow
-        }
-
-        var currentBytes = downloadedBytes
-        var lastProgressUpdateTime = System.currentTimeMillis()
-        var lastDownloadedBytesForSpeed = downloadedBytes
-        emit(
-            DownloadState.InProgress(
-                calculateProgress(currentBytes, totalBytes),
-                currentBytes,
-                totalBytes, 0
-            )
-        )
-
-        // 3. 将数据写入临时文件
-        response.body?.byteStream().use { input ->
-            RandomAccessFile(tempFile, "rw").use { output ->
-                output.seek(downloadedBytes) // 移动到文件末尾
-                val buffer = ByteArray(8 * 1024)
-                var bytesRead: Int
-                while (input?.read(buffer).also { bytesRead = it ?: -1 } != -1) {
-                    output.write(buffer, 0, bytesRead)
-                    currentBytes += bytesRead
-                    val currentTime = System.currentTimeMillis()
-                    val deltaTime = currentTime - lastProgressUpdateTime
-                    if (deltaTime >= PROGRESS_UPDATE_INTERVAL) {
-                        val deltaBytes = currentBytes - lastDownloadedBytesForSpeed
-                        val speedBps = if (deltaTime > 0) (deltaBytes * 1000 / deltaTime) else 0
-                        // 节流，避免过于频繁地发射状态
-                        emit(
-                            DownloadState.InProgress(
-                                calculateProgress(currentBytes, totalBytes),
-                                currentBytes,
-                                totalBytes, speedBps
-                            )
-                        )
-                        lastProgressUpdateTime = currentTime
-                        lastDownloadedBytesForSpeed = currentBytes
-                    }
-                    // [NEW] 从外部获取当前任务状态
-                    val currentStatus = stateChecker.invoke()
-
-                    if (currentStatus == DownloadStatus.PAUSED) {
-                        // 感知到暂停指令，优雅地退出
-                        emit(DownloadState.Paused) // 定义一个新的 Paused 状态
-                        return@flow
-                    }
-                    if (currentStatus == DownloadStatus.CANCELED) {
-                        // 感知到取消指令，抛出异常以终止流程
-                        throw CancellationException("Task was cancelled by user.")
-                    }
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    // HEAD请求失败，降级到单线程
+                    return false
                 }
+                // 关键：检查Accept-Ranges头（bytes表示支持，none表示不支持）
+                val acceptRanges = response.header("Accept-Ranges") ?: "none"
+                val isSupported = acceptRanges.equals("bytes", ignoreCase = true)
+
+                // 额外校验：部分服务器返回Content-Length但不支持Range，需二次验证
+                if (isSupported) {
+                    val contentLength = response.header("Content-Length")?.toLongOrNull() ?: 0L
+                    // 小文件（<10MB）直接用单线程，避免多线程开销
+                    return contentLength > 10 * 1024 * 1024L
+                }
+                return false
             }
-        }
-
-        try {
-            val finalAbsolutePath = FileUtil.moveToPublicDirectory(
-                context = DownloaderManager.context!!,
-                sourceFile = tempFile,
-                finalPath = task.filePath,
-                fileName = task.fileName,
-                mimeType = mimeType
-            )
-            emit(DownloadState.Success)
-            DownloaderManager.config.logger.d(TAG, "finalAbsolutePath:$finalAbsolutePath")
         } catch (e: Exception) {
-            emit(
-                DownloadState.Error(
-                    "Failed to move temp file to final destination: ${e.message}",
-                    e
-                )
-            )
+            // 任何异常 → 降级到单线程
+            false
         }
-
-    }.flowOn(Dispatchers.IO) // 确保所有 IO 操作都在 IO 线程
-
-    private fun calculateProgress(downloaded: Long, total: Long): Int {
-        return if (total > 0) ((downloaded * 100) / total).toInt() else 0
     }
 }

--- a/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/strategy/HttpMultiDownloadStrategy.kt
+++ b/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/strategy/HttpMultiDownloadStrategy.kt
@@ -1,0 +1,391 @@
+package com.awesome.dhs.tools.downloader.strategy
+
+import com.awesome.dhs.tools.downloader.DownloaderManager
+import com.awesome.dhs.tools.downloader.db.DownloadTaskEntity
+import com.awesome.dhs.tools.downloader.interfac.IDownloadStrategy
+import com.awesome.dhs.tools.downloader.model.DownloadState
+import com.awesome.dhs.tools.downloader.model.DownloadStatus
+import com.awesome.dhs.tools.downloader.utils.FileNameResolver.getMimeType
+import com.awesome.dhs.tools.downloader.utils.FileUtil
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.also
+import kotlin.apply
+import kotlin.collections.forEach
+import kotlin.collections.isNotEmpty
+import kotlin.collections.set
+import kotlin.io.use
+import kotlin.run
+import kotlin.text.toLong
+import kotlin.to
+
+/**
+ * 动态小块分片下载策略（修复暂停误判失败问题）
+ */
+class HttpMultiDownloadStrategy : IDownloadStrategy {
+    companion object {
+        private const val TAG = "HttpMultiDownloadStrategy"
+        private const val PROGRESS_UPDATE_INTERVAL = 1000L
+        private const val CHUNK_SIZE = 1024 * 1024L
+        private const val MAX_CHUNK_RETRY = 3
+    }
+
+    private val pendingChunks = ConcurrentLinkedQueue<LongRange>()
+    private val completedBytes = AtomicLong(0)
+    private var totalFileSize = 0L
+    private val speedHistory = ConcurrentLinkedQueue<Pair<Long, Long>>()
+    private val chunkRetryMap = ConcurrentHashMap<LongRange, Int>()
+    // 新增：标记是否为主动暂停/取消（核心修复点）
+    private val isPausedOrCanceled = AtomicBoolean(false)
+
+    override fun download(
+        task: DownloadTaskEntity,
+        client: OkHttpClient,
+        stateChecker: suspend () -> DownloadStatus?,
+    ): Flow<DownloadState> = channelFlow {
+        // 初始化
+        pendingChunks.clear()
+        completedBytes.set(0)
+        speedHistory.clear()
+        chunkRetryMap.clear()
+        isPausedOrCanceled.set(false) // 重置暂停标记
+        // 步骤1：获取文件总大小
+        totalFileSize = if (task.totalBytes > 0) {
+            task.totalBytes
+        } else {
+            getFileTotalSize(task.url, client) ?: run {
+                send(DownloadState.Error("无法获取文件总大小"))
+                return@channelFlow
+            }
+        }
+
+        // 步骤2：初始化未下载区间池
+        initPendingChunks(File(task.tempFilePath), totalFileSize)
+
+        // 无未下载区间，直接返回成功
+        if (pendingChunks.isEmpty()) {
+            try {
+                val finalPath = moveTempFileToFinal(task, totalFileSize)
+                DownloaderManager.config.logger.d("HttpMultiDownloadStrategy", "文件已完整，直接完成：$finalPath")
+                send(DownloadState.Success)
+            } catch (e: Exception) {
+                send(DownloadState.Error("文件移动失败：${e.message}", e))
+            }
+            return@channelFlow
+        }
+
+        // 步骤3：核心下载逻辑（重构为独立函数，便于异常处理）
+        try {
+            executeDownload(task, client, stateChecker, this) { state ->
+                // 转发状态到 channelFlow
+                send(state)
+            }
+        } catch (e: CancellationException) {
+            // 捕获暂停/取消异常，标记状态并发送 Paused
+            isPausedOrCanceled.set(true)
+            DownloaderManager.config.logger.d("HttpMultiDownloadStrategy", "任务主动暂停/取消：${e.message}")
+            send(DownloadState.Paused)
+        } catch (e: Exception) {
+            // 仅捕获真正的下载异常，发送 Error
+            if (!isPausedOrCanceled.get()) { // 排除暂停/取消导致的异常
+                DownloaderManager.config.logger.e(TAG, "下载异常", e)
+                send(DownloadState.Error("下载失败：${e.message}", e))
+            }
+        }
+
+    }.flowOn(Dispatchers.IO)
+        .onCompletion {
+            // 清理资源
+            pendingChunks.clear()
+            completedBytes.set(0)
+            speedHistory.clear()
+            chunkRetryMap.clear()
+            isPausedOrCanceled.set(false)
+        }
+
+    /**
+     * 独立的下载执行逻辑（核心修复：分离暂停/失败判断）
+     */
+    private suspend fun executeDownload(
+        task: DownloadTaskEntity,
+        client: OkHttpClient,
+        stateChecker: suspend () -> DownloadStatus?,
+        scope: CoroutineScope, // 新增：接收协程作用域
+        onState: suspend (DownloadState) -> Unit
+    ) {
+        // 启动进度发射协程
+        val progressJob = scope.launch(Dispatchers.IO) {
+            while (isActive && completedBytes.get() < totalFileSize) {
+                // 检查暂停/取消状态（提前判断，避免无效发射）
+                val status = stateChecker.invoke()
+                if (status == DownloadStatus.PAUSED || status == DownloadStatus.CANCELED) {
+                    isPausedOrCanceled.set(true)
+                    throw CancellationException(if (status == DownloadStatus.PAUSED) "任务暂停" else "任务取消")
+                }
+
+                // 发射进度
+                val progress = calculateProgress(completedBytes.get(), totalFileSize)
+                val speed = calculateDownloadSpeed()
+                onState(
+                    DownloadState.InProgress(
+                        progress = progress,
+                        downloadedBytes = completedBytes.get(),
+                        totalBytes = totalFileSize,
+                        speedBps = speed
+                    )
+                )
+
+                delay(PROGRESS_UPDATE_INTERVAL)
+            }
+        }
+
+        // 启动下载线程
+        val downloadJobs = mutableListOf<Job>()
+        repeat(DownloaderManager.config.downloadThreadCount) { threadIndex ->
+            val job = scope.launch(Dispatchers.IO) {
+                downloadWorker(threadIndex, task, client, stateChecker)
+            }
+            downloadJobs.add(job)
+        }
+
+        // 等待所有下载线程完成（若中途暂停，会抛出 CancellationException）
+        downloadJobs.joinAll()
+        progressJob.cancel()
+
+        // 仅当不是暂停/取消时，才校验文件完整性
+        if (!isPausedOrCanceled.get()) {
+            if (completedBytes.get() == totalFileSize) {
+                val finalPath = moveTempFileToFinal(task, totalFileSize)
+                DownloaderManager.config.logger.d(TAG, "下载完成，最终路径：$finalPath")
+                onState(DownloadState.Success)
+            } else {
+                // 真正的下载不完整（非暂停导致）
+                onState(DownloadState.Error("文件下载不完整：${completedBytes.get()}/${totalFileSize}"))
+            }
+        }
+    }
+
+    /**
+     * 单个下载线程逻辑（新增暂停检查）
+     */
+    private suspend fun downloadWorker(
+        threadIndex: Int,
+        task: DownloadTaskEntity,
+        client: OkHttpClient,
+        stateChecker: suspend () -> DownloadStatus?
+    ) {
+        val tempFile = File(task.tempFilePath)
+        DownloaderManager.config.logger.d(TAG, "线程$threadIndex 启动，开始抢块下载")
+
+        while (pendingChunks.isNotEmpty() && !isPausedOrCanceled.get()) { // 新增：检查暂停标记
+            val chunkRange = pendingChunks.poll() ?: break
+            val start = chunkRange.start
+            val end = chunkRange.endInclusive
+
+            // 双重检查：状态 + 原子标记
+            val currentStatus = stateChecker.invoke()
+            if (currentStatus == DownloadStatus.PAUSED || currentStatus == DownloadStatus.CANCELED) {
+                isPausedOrCanceled.set(true)
+                pendingChunks.offer(chunkRange) // 放回未下载小块
+                DownloaderManager.config.logger.d(TAG, "线程$threadIndex 检测到暂停/取消，放回小块：$chunkRange")
+                break
+            }
+
+            try {
+                downloadSingleChunk(threadIndex, task, client, tempFile, start, end)
+                val chunkSize = end - start + 1
+                completedBytes.addAndGet(chunkSize)
+                DownloaderManager.config.logger.d(TAG, "线程$threadIndex 完成小块：$chunkRange，已完成：${completedBytes.get()}/${totalFileSize}")
+            } catch (e: Exception) {
+                // 若已暂停，不再重试，直接退出
+                if (isPausedOrCanceled.get()) break
+
+                val retryCount = chunkRetryMap.getOrDefault(chunkRange, 0) + 1
+                chunkRetryMap[chunkRange] = retryCount
+
+                if (retryCount <= MAX_CHUNK_RETRY) {
+                    pendingChunks.offer(chunkRange)
+                    val delayTime = 1000L * retryCount
+                    DownloaderManager.config.logger.d(TAG, "线程$threadIndex 小块$chunkRange 下载失败（第$retryCount 次），${delayTime}ms后重试：${e.message}")
+                    delay(delayTime)
+                } else {
+                    val errorMsg = "线程$threadIndex 小块$chunkRange 下载失败（重试$MAX_CHUNK_RETRY 次）：${e.message}"
+                    DownloaderManager.config.logger.e(TAG, errorMsg, e)
+                    throw IOException(errorMsg, e)
+                }
+            }
+        }
+
+        DownloaderManager.config.logger.d(TAG, "线程$threadIndex 退出（暂停标记：${isPausedOrCanceled.get()}）")
+    }
+
+    // 以下方法无核心修改，仅保留完整代码
+    private fun downloadSingleChunk(
+        threadIndex: Int,
+        task: DownloadTaskEntity,
+        client: OkHttpClient,
+        tempFile: File,
+        start: Long,
+        end: Long
+    ) {
+        val request = Request.Builder()
+            .url(task.url)
+            .header("Range", "bytes=$start-$end")
+            .apply {
+                task.headers.forEach { (key, value) ->
+                    addHeader(key, value)
+                }
+            }
+            .build()
+
+        val response = client.newCall(request).execute()
+        if (!response.isSuccessful && response.code != 206) {
+            throw IOException("小块$start-$end 请求失败，响应码：${response.code}")
+        }
+
+        response.body?.byteStream()?.use { inputStream ->
+            RandomAccessFile(tempFile, "rw").use { raf ->
+                raf.seek(start)
+                val buffer = ByteArray(8 * 1024)
+                var bytesRead: Int
+                while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                    raf.write(buffer, 0, bytesRead)
+                }
+            }
+        }
+
+        if (!isChunkValid(tempFile, start, end)) {
+            throw IOException("小块$start-$end 数据验证失败")
+        }
+    }
+
+    private fun initPendingChunks(tempFile: File, totalSize: Long) {
+        DownloaderManager.config.logger.d(TAG, "初始化未下载区间池，文件总大小：$totalSize")
+
+        if (!tempFile.exists()) {
+            splitIntoChunks(0L, totalSize)
+            DownloaderManager.config.logger.d(TAG, "全新下载，拆分出 ${pendingChunks.size} 个小块")
+            return
+        }
+
+        val fileLength = tempFile.length()
+        var current = 0L
+        var downloadedChunks = 0
+        var pendingChunksCount = 0
+
+        while (current < totalSize) {
+            val chunkEnd = kotlin.comparisons.minOf(current + CHUNK_SIZE - 1, totalSize - 1)
+            val isChunkDownloaded = fileLength > chunkEnd && isChunkValid(tempFile, current, chunkEnd)
+
+            if (isChunkDownloaded) {
+                completedBytes.addAndGet(chunkEnd - current + 1)
+                downloadedChunks++
+            } else {
+                pendingChunks.offer(current..chunkEnd)
+                pendingChunksCount++
+            }
+
+            current = chunkEnd + 1
+        }
+
+        DownloaderManager.config.logger.d(TAG, "断点续传扫描完成：已下载$downloadedChunks 个小块，待下载$pendingChunksCount 个小块")
+    }
+
+    private fun splitIntoChunks(start: Long, end: Long) {
+        var current = start
+        while (current <= end) {
+            val chunkEnd = kotlin.comparisons.minOf(current + CHUNK_SIZE - 1, end)
+            pendingChunks.offer(current..chunkEnd)
+            current = chunkEnd + 1
+        }
+    }
+
+    private fun isChunkValid(file: File, start: Long, end: Long): Boolean {
+        return try {
+            RandomAccessFile(file, "r").use { raf ->
+                raf.seek(start)
+                val buffer = ByteArray(1)
+                raf.read(buffer) != -1
+            }
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun getFileTotalSize(url: String, client: OkHttpClient): Long? {
+        return try {
+            val request = Request.Builder()
+                .url(url)
+                .head()
+                .build()
+
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    DownloaderManager.config.logger.e(TAG, "获取文件大小失败，响应码：${response.code}")
+                    return null
+                }
+                response.header("Content-Length")?.toLong()
+            }
+        } catch (e: Exception) {
+            DownloaderManager.config.logger.e(TAG, "获取文件大小异常", e)
+            null
+        }
+    }
+
+    private fun calculateProgress(downloaded: Long, total: Long): Int {
+        return if (total > 0) ((downloaded * 100) / total).toInt() else 0
+    }
+
+    private fun calculateDownloadSpeed(): Long {
+        val currentTime = System.currentTimeMillis()
+        val currentBytes = completedBytes.get()
+
+        speedHistory.offer(currentTime to currentBytes)
+
+        while (speedHistory.isNotEmpty() && currentTime - speedHistory.peek()!!.first > 5000) {
+            speedHistory.poll()
+        }
+
+        if (speedHistory.size < 2) return 0
+
+        val firstRecord = speedHistory.peek()!!
+        val deltaTime = currentTime - firstRecord.first
+        val deltaBytes = currentBytes - firstRecord.second
+
+        return if (deltaTime > 0) (deltaBytes * 1000 / deltaTime) else 0
+    }
+
+    private suspend fun moveTempFileToFinal(task: DownloadTaskEntity, totalSize: Long): String {
+        val tempFile = File(task.tempFilePath)
+        if (tempFile.length() != totalSize) {
+            throw IOException("临时文件大小不符：${tempFile.length()} vs $totalSize")
+        }
+        val mimeType = task.fileName.getMimeType() ?: "application/octet-stream"
+        return FileUtil.moveToPublicDirectory(
+            context = DownloaderManager.context!!,
+            sourceFile = tempFile,
+            finalPath = task.filePath,
+            fileName = task.fileName,
+            mimeType = mimeType
+        )
+    }
+}

--- a/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/strategy/HttpMultiDownloadStrategy.kt
+++ b/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/strategy/HttpMultiDownloadStrategy.kt
@@ -77,6 +77,10 @@ class HttpMultiDownloadStrategy : IDownloadStrategy {
                 return@channelFlow
             }
         }
+        // 这里没有去初始化直接设置 RandomAccessFile 大小，考虑两点
+        // 1.下载开始直接设置文件大小，用户端会很奇怪，刚开始下载就直接占了手机空间，这个应该由业务决定
+        // 2.分片下载的数据没有被保存在数据库中，每次会根据已下载文件的当前大小来决定后续分片，直接设置大小会导致
+        // isChunkValid 这个方法永远返回 true,如果有本地数据存储了分片下载数据，可以考虑前置设置文件大小
 
         // 步骤2：初始化未下载区间池
         initPendingChunks(File(task.tempFilePath), totalFileSize)
@@ -179,6 +183,7 @@ class HttpMultiDownloadStrategy : IDownloadStrategy {
                 onState(DownloadState.Success)
             } else {
                 // 真正的下载不完整（非暂停导致）
+                DownloaderManager.config.logger.d(TAG, "文件下载不完整：${completedBytes.get()}/${totalFileSize}")
                 onState(DownloadState.Error("文件下载不完整：${completedBytes.get()}/${totalFileSize}"))
             }
         }
@@ -262,8 +267,9 @@ class HttpMultiDownloadStrategy : IDownloadStrategy {
             throw IOException("小块$start-$end 请求失败，响应码：${response.code}")
         }
 
-        response.body?.byteStream()?.use { inputStream ->
-            RandomAccessFile(tempFile, "rw").use { raf ->
+        val raf = RandomAccessFile(tempFile, "rw")
+        response.body.byteStream().use { inputStream ->
+            raf.let { raf ->
                 raf.seek(start)
                 val buffer = ByteArray(8 * 1024)
                 var bytesRead: Int
@@ -272,17 +278,21 @@ class HttpMultiDownloadStrategy : IDownloadStrategy {
                 }
             }
         }
-
-        if (!isChunkValid(tempFile, start, end)) {
+        // 刷新磁盘
+        raf.fd.sync()
+        if (!isChunkValid(raf, start, end)) {
             throw IOException("小块$start-$end 数据验证失败")
         }
+        // 关闭流
+        raf.close()
     }
 
     private fun initPendingChunks(tempFile: File, totalSize: Long) {
         DownloaderManager.config.logger.d(TAG, "初始化未下载区间池，文件总大小：$totalSize")
 
-        if (!tempFile.exists()) {
-            splitIntoChunks(0L, totalSize)
+        if (!tempFile.exists() || tempFile.length() == 0L) {
+            // 0 ~ totalFileSize - 1
+            splitIntoChunks(0L, totalSize - 1)
             DownloaderManager.config.logger.d(TAG, "全新下载，拆分出 ${pendingChunks.size} 个小块")
             return
         }
@@ -292,9 +302,10 @@ class HttpMultiDownloadStrategy : IDownloadStrategy {
         var downloadedChunks = 0
         var pendingChunksCount = 0
 
+        val raf = RandomAccessFile(tempFile,"r")
         while (current < totalSize) {
             val chunkEnd = kotlin.comparisons.minOf(current + CHUNK_SIZE - 1, totalSize - 1)
-            val isChunkDownloaded = fileLength > chunkEnd && isChunkValid(tempFile, current, chunkEnd)
+            val isChunkDownloaded = fileLength > chunkEnd && isChunkValid(raf, current, chunkEnd)
 
             if (isChunkDownloaded) {
                 completedBytes.addAndGet(chunkEnd - current + 1)
@@ -319,9 +330,9 @@ class HttpMultiDownloadStrategy : IDownloadStrategy {
         }
     }
 
-    private fun isChunkValid(file: File, start: Long, end: Long): Boolean {
+    private fun isChunkValid(raf: RandomAccessFile, start: Long, end: Long): Boolean {
         return try {
-            RandomAccessFile(file, "r").use { raf ->
+            raf.let { raf ->
                 raf.seek(start)
                 val buffer = ByteArray(1)
                 raf.read(buffer) != -1

--- a/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/strategy/HttpSingleDownloadStrategy.kt
+++ b/titan-downloader/src/main/java/com/awesome/dhs/tools/downloader/strategy/HttpSingleDownloadStrategy.kt
@@ -1,0 +1,148 @@
+package com.awesome.dhs.tools.downloader.strategy
+
+
+/**
+ * FileName: HttpDownloadStrategy
+ * Author: haosen
+ * Date: 10/3/2025 4:44 AM
+ * Description:
+ **/
+import com.awesome.dhs.tools.downloader.DownloaderManager
+import com.awesome.dhs.tools.downloader.db.DownloadTaskEntity
+import com.awesome.dhs.tools.downloader.interfac.IDownloadStrategy
+import com.awesome.dhs.tools.downloader.model.DownloadState
+import com.awesome.dhs.tools.downloader.model.DownloadStatus
+import com.awesome.dhs.tools.downloader.utils.FileNameResolver.getMimeType
+import com.awesome.dhs.tools.downloader.utils.FileUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import kotlin.coroutines.cancellation.CancellationException
+
+class HttpSingleDownloadStrategy : IDownloadStrategy {
+    companion object {
+        // How often to update progress and speed, in milliseconds.
+        private const val PROGRESS_UPDATE_INTERVAL = 1000L
+    }
+
+    override fun download(
+        task: DownloadTaskEntity,
+        client: OkHttpClient,
+        stateChecker: suspend () -> DownloadStatus?,
+    ): Flow<DownloadState> = flow {
+        val tempFile = File(task.tempFilePath)
+        val downloadedBytes = if (tempFile.exists()) tempFile.length() else 0L
+
+        // 1. 构建支持断点续传的请求
+        val request = Request.Builder()
+            .url(task.url)
+            .header("Range", "bytes=$downloadedBytes-")
+            .apply { task.headers.forEach { (key, value) -> addHeader(key, value) } }
+            .build()
+
+        val response = try {
+            client.newCall(request).execute()
+        } catch (e: IOException) {
+            emit(DownloadState.Error("Network error: ${e.message}", e))
+            return@flow
+        }
+
+        if (!response.isSuccessful && response.code != 206) { // 206 Partial Content
+            emit(DownloadState.Error("Unexpected response code: ${response.code}"))
+            return@flow
+        }
+
+        // 2. 获取文件总大小
+        val totalBytes =
+            response.header("Content-Length")?.toLongOrNull()?.let { it + downloadedBytes }
+                ?: (task.totalBytes.takeIf { it > 0 } ?: -1L)
+
+        val mimeType = task.fileName.getMimeType() ?: response.header("Content-Type")
+        if (totalBytes == -1L && downloadedBytes == 0L) {
+            emit(DownloadState.Error("Could not determine file size."))
+            return@flow
+        }
+
+        var currentBytes = downloadedBytes
+        var lastProgressUpdateTime = System.currentTimeMillis()
+        var lastDownloadedBytesForSpeed = downloadedBytes
+        emit(
+            DownloadState.InProgress(
+                calculateProgress(currentBytes, totalBytes),
+                currentBytes,
+                totalBytes, 0
+            )
+        )
+
+        // 3. 将数据写入临时文件
+        response.body?.byteStream().use { input ->
+            RandomAccessFile(tempFile, "rw").use { output ->
+                output.seek(downloadedBytes) // 移动到文件末尾
+                val buffer = ByteArray(8 * 1024)
+                var bytesRead: Int
+                while (input?.read(buffer).also { bytesRead = it ?: -1 } != -1) {
+                    output.write(buffer, 0, bytesRead)
+                    currentBytes += bytesRead
+                    val currentTime = System.currentTimeMillis()
+                    val deltaTime = currentTime - lastProgressUpdateTime
+                    if (deltaTime >= PROGRESS_UPDATE_INTERVAL) {
+                        val deltaBytes = currentBytes - lastDownloadedBytesForSpeed
+                        val speedBps = if (deltaTime > 0) (deltaBytes * 1000 / deltaTime) else 0
+                        // 节流，避免过于频繁地发射状态
+                        emit(
+                            DownloadState.InProgress(
+                                calculateProgress(currentBytes, totalBytes),
+                                currentBytes,
+                                totalBytes, speedBps
+                            )
+                        )
+                        lastProgressUpdateTime = currentTime
+                        lastDownloadedBytesForSpeed = currentBytes
+                    }
+                    // [NEW] 从外部获取当前任务状态
+                    val currentStatus = stateChecker.invoke()
+
+                    if (currentStatus == DownloadStatus.PAUSED) {
+                        // 感知到暂停指令，优雅地退出
+                        emit(DownloadState.Paused) // 定义一个新的 Paused 状态
+                        return@flow
+                    }
+                    if (currentStatus == DownloadStatus.CANCELED) {
+                        // 感知到取消指令，抛出异常以终止流程
+                        throw CancellationException("Task was cancelled by user.")
+                    }
+                }
+            }
+        }
+
+        try {
+            val finalAbsolutePath = FileUtil.moveToPublicDirectory(
+                context = DownloaderManager.context!!,
+                sourceFile = tempFile,
+                finalPath = task.filePath,
+                fileName = task.fileName,
+                mimeType = mimeType
+            )
+            emit(DownloadState.Success)
+            DownloaderManager.config.logger.d("HttpSingleDownloadStrategy", "finalAbsolutePath:$finalAbsolutePath")
+        } catch (e: Exception) {
+            emit(
+                DownloadState.Error(
+                    "Failed to move temp file to final destination: ${e.message}",
+                    e
+                )
+            )
+        }
+
+    }.flowOn(Dispatchers.IO) // 确保所有 IO 操作都在 IO 线程
+
+    private fun calculateProgress(downloaded: Long, total: Long): Int {
+        return if (total > 0) ((downloaded * 100) / total).toInt() else 0
+    }
+}


### PR DESCRIPTION
采取了以下建议，优化了下逻辑
问题1：频繁打开/关闭文件流（IO 性能损耗）
解决：将分片大小调整为 4M，每次分片还是创建 RandomAccessFile 去读写，保留全局的 RandomAccessFile 去读写，发现下载下来文件大小与请求的文件大小总是不一致，暂不清楚什么原因导致
问题3：数据落盘的同步性（断点续传的可靠性）
解决：在每次写完一个分片数据后 sync 一下，同步磁盘数据，没考虑间隔时间去刷新，在是网络较差的时候，间隔时间内没有数据需要同步就没有必要 sync 了
问题4：并发控制与网络拥塞
解决：在外层设置setDownloadThreadCount时，限制1..5

暂不处理 
问题2：缺乏文件预分配（磁盘空间与碎片化风险）
1.下载开始直接设置文件大小，用户端会很奇怪，刚开始下载就直接占了手机空间，很奇怪，理论这个应该由业务决定
2.分片下载的数据没有被保存在数据库中，每次会根据已下载文件的当前大小来决定后续分片，直接设置大小会导致 isChunkValid 这个方法永远返回 true,如果有本地数据存储了分片下载数据，可以考虑前置设置文件大小



